### PR TITLE
ci: check commit signoffs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,6 +5,8 @@ include:
   - component: gitlab.com/Northern.tech/Mender/mendertesting/commit-lint@master
   - project: 'Northern.tech/Mender/mendertesting'
     file:
+      # QA-1046 Remove after hardening sign-off checks in the modern commit linter
+      - '.gitlab-ci-check-commits-signoffs.yml'
       - '.gitlab-ci-check-license.yml'
       - '.gitlab-ci-github-status-updates.yml'
       - '.gitlab-ci-check-shell-format.yml'


### PR DESCRIPTION
Our (new) commit-linter isn't strict enough, see
QA-1046.