### PR TITLE
fix: don't make images directory unless necessary

### DIFF
--- a/src/gen_docker-compose
+++ b/src/gen_docker-compose
@@ -212,8 +212,8 @@ function cleanup() {
 }
 trap cleanup EXIT SIGQUIT SIGTERM
 
-mkdir $temp_dir/images
 if [ -z "${images_dir}" ]; then
+    mkdir $temp_dir/images
     for image in $images; do
         file_name=$(echo "$image" | tr '/:@' '_')
         echo "Downloading image: $image"


### PR DESCRIPTION
Fixed an issue where images would end up at `${temp_dir}/images/images` instead of `${temp_dir}/images` by ensuring that we only create the directory when `--images-dir` isn't specified.

Ticket: None