### PR TITLE
fix: Handle arguments parsing and passing safely in gen_docker-compose

### DIFF
--- a/src/gen_docker-compose
+++ b/src/gen_docker-compose
@@ -65,10 +65,10 @@ if ! check_dependency skopeo; then
 fi
 
 declare -a device_types
+declare -a passthrough_args
 artifact_name=""
 output_path="docker-compose-artifact.mender"
 project_name=""
-passthrough_args=""
 version="1.0"
 manifests_dir=""
 images_dir=""
@@ -110,7 +110,7 @@ while test $# -gt 0; do
             if [ -z "$2" ]; then
                 show_help_and_exit_error
             fi
-            device_types+=("$2")
+            device_types+=("-t" "$2")
             shift 2
             ;;
         --artifact-name | -n)
@@ -144,7 +144,7 @@ while test $# -gt 0; do
             ;;
         --)
             shift
-            passthrough_args="$@"
+            passthrough_args=("$@")
             break
             ;;
         -*)
@@ -240,31 +240,28 @@ cat << EOF > "${temp_dir}/meta.json"
 {"version": "1", "project_name": "$project_name"}
 EOF
 
-write_artifact_cmd="mender-artifact write module-image"
-write_artifact_cmd+=" --type docker-compose"
-write_artifact_cmd+=" --compression none"
-write_artifact_cmd+=" --artifact-name ${artifact_name}"
-write_artifact_cmd+=" -f ${temp_dir}/images.tar.gz -f ${temp_dir}/manifests.tar"
-write_artifact_cmd+=" --meta-data ${temp_dir}/meta.json"
-write_artifact_cmd+=" --output-path ${output_path}"
-
 # Just make sure the project name is in the software name and that it's clear
 # that it's handled by the docker-compose Update Module.
 # We cannot set --software-filesystem because we don't know where docker stores
 # images. The user has to do that themselves (and there is a hint about this in
 # the --help output).
-write_artifact_cmd+=" --software-name mender-docker-compose.${project_name}"
+software_name="mender-docker-compose.${project_name}"
 
 # There can only be one project handled by the docker-compose Update Module so
 # every new one installed removes any old installed before.
-write_artifact_cmd+=" --clears-provides *mender-docker-compose_*"
-write_artifact_cmd+=" --no-default-clears-provides"
+clears_provides="*mender-docker-compose_*"
 
-for ((i = 0; i < ${#device_types[@]}; i++)); do
-    write_artifact_cmd+=" --device-type ${device_types[${i}]}"
-done
-
-$write_artifact_cmd $passthrough_args
+mender-artifact write module-image \
+    --type docker-compose \
+    --compression none \
+    --artifact-name "${artifact_name}" \
+    "${device_types[@]}" \
+    -f "${temp_dir}/images.tar.gz" -f "${temp_dir}/manifests.tar" \
+    --meta-data "${temp_dir}/meta.json" \
+    --output-path "${output_path}" \
+    --software-name "${software_name}" \
+    --clears-provides "${clears_provides}" --no-default-clears-provides \
+    "${passthrough_args[@]}"
 rc=$?
 
 if [ $rc = 0 ]; then


### PR DESCRIPTION
Fix how gen_docker-compose parses arguments and passes them to mender-artifact. It needs to be more careful to prevent injected extra arguments going through the script to mender-artifact.

Ticket: MEN-9115
Changelog: none

Related to https://github.com/mendersoftware/mender/pull/1865