### PR TITLE
feat: support pulling images when not embedded in artifacts

### DIFF
--- a/src/docker-compose
+++ b/src/docker-compose
@@ -119,6 +119,25 @@ container_image_load() {
     $DOCKER_CMD image load --input "$input_file"
 }
 
+container_image_pull() {
+    local manifests_dir="$1/manifests"
+    local project_name=$(cat "$1/project_name")
+    local rc=0
+
+    echo "Pulling images for $1 from registry"
+    (
+        cd "$manifests_dir"
+        $DOCKER_COMPOSE_CMD \
+            --project-name "$project_name" \
+            pull
+    ) || rc=$?
+
+    if test "$rc" -ne 0; then
+        echo "Failed to pull images from registry" 1>&2
+    fi
+    return "$rc"
+}
+
 comp_stop() {
     local manifests_dir="$1/manifests"
     local project_name=$(cat "$1/project_name")
@@ -219,6 +238,7 @@ get_manifest_image_ids() {
 
 install_artifact() {
     local artifact_files="$1"
+    local has_images=true
     local rc=0
 
     echo "Installing docker-compose artifact ${ARTIFACT_NAME}"
@@ -244,8 +264,13 @@ install_artifact() {
         return 1
     fi
 
-    echo "extracting images"
-    $TAR_CMD -xzf "${artifact_files}/images.tar.gz" -C "$TEMP_DIR"
+    if test ! -f "${artifact_files}/images.tar.gz"; then
+        echo "Images not bundled in artifact, pulling them from the registry"
+        has_images=false
+    else
+        echo "extracting images"
+        $TAR_CMD -xzf "${artifact_files}/images.tar.gz" -C "$TEMP_DIR"
+    fi
     echo "extracting manifests"
     $TAR_CMD -xf "${artifact_files}/manifests.tar" -C "$TEMP_DIR"
 
@@ -253,15 +278,21 @@ install_artifact() {
     cp -r "${TEMP_DIR}/manifests" "${PERSISTENT_STORE}/new/"
     echo "${PROJECT_NAME}" > "${PERSISTENT_STORE}/new/project_name"
 
-    local image
-    for image in "${TEMP_DIR}/images/"*; do
-        if ! container_image_load "$image"; then
-            # Make sure to gather the IDs of loaded images below for cleanup.
+    if [ "$has_images" = true ]; then
+        local image
+        for image in "${TEMP_DIR}/images/"*; do
+            if ! container_image_load "$image"; then
+                rc=2
+                break
+            fi
+        done
+    else
+        if ! container_image_pull "${PERSISTENT_STORE}/new"; then
             rc=2
-            break
         fi
-    done
+    fi
 
+    # Gather image IDs for cleanup later
     local manifest
     for manifest in "${PERSISTENT_STORE}/new/manifests/"*; do
         get_manifest_image_ids "$manifest" >> "${PERSISTENT_STORE}/new/image_ids"
@@ -323,6 +354,7 @@ cleanup() {
         return 0
     fi
 
+    # only remove images that are not used by current
     local image_id
     while read -r image_id; do
         if ! grep -qF "$image_id" "${PERSISTENT_STORE}/current/image_ids" 2> /dev/null; then

--- a/src/gen_docker-compose
+++ b/src/gen_docker-compose
@@ -23,7 +23,7 @@ Simple tool to generate Mender Artifacts suitable for the docker-compose module
 
 Usage: $0 [options] [-- [options-for-mender-artifact] ]
 
-    Options: [ -n|--artifact-name -t|--device-type -o|--output_path -a|--architecture -l|--list-architectures -i|--images-dir -m|--manifests-dir -h|--help -p|--project-name]
+    Options: [ -n|--artifact-name -t|--device-type -o|--output_path -a|--architecture -l|--list-architectures -i|--images-dir -s|--skip-images -m|--manifests-dir -h|--help -p|--project-name]
 
         --artifact-name      - Artifact name
         --device-type        - Target device type identification (can be given more than once)
@@ -31,6 +31,7 @@ Usage: $0 [options] [-- [options-for-mender-artifact] ]
         --list-architectures - List the available architectures of the images in the manifests
         --architecture       - The architecture to download the images for. See --list-architectures for available architectures.
         --images-dir         - Directory containing container images the composition needs
+        --skip-images        - Skip adding images to the artifact and include only the manifests
         --manifests-dir      - Directory containing docker compose manifests
         --project-name       - Name of the docker compose project, must contain only characters from the class $PROJECT_NAME_ALLOWED_REGEX
         --help               - Show help and exit
@@ -66,6 +67,7 @@ fi
 
 declare -a device_types
 declare -a passthrough_args
+declare -a artifact_files
 artifact_name=""
 output_path="docker-compose-artifact.mender"
 project_name=""
@@ -74,6 +76,7 @@ manifests_dir=""
 images_dir=""
 architecture=""
 list_architectures=false
+skip_images=false
 
 if [ $# -eq 0 ]; then
     show_help_and_exit_error
@@ -91,6 +94,10 @@ while test $# -gt 0; do
                 show_help_and_exit_error
             fi
             shift 2
+            ;;
+        --skip-images | -s)
+            skip_images=true
+            shift 1
             ;;
         --manifests-dir | -m)
             if [ -z "$2" ]; then
@@ -212,7 +219,7 @@ function cleanup() {
 }
 trap cleanup EXIT SIGQUIT SIGTERM
 
-if [ -z "${images_dir}" ]; then
+if [ -z "${images_dir}" ] && [ "$skip_images" = false ]; then
     mkdir $temp_dir/images
     for image in $images; do
         file_name=$(echo "$image" | tr '/:@' '_')
@@ -222,20 +229,24 @@ if [ -z "${images_dir}" ]; then
             exit 1
         fi
     done
-elif ! [ -d "${images_dir}" ]; then
+elif ! [ -d "${images_dir}" ] && [ "$skip_images" = false ]; then
     echo "Images directory '${images_dir}' doesn't exist. Aborting." >&2
     show_help_and_exit_error
-elif [ $(ls -1 "${images_dir}" | wc -l) -eq 0 ]; then
+elif [ $(ls -1 "${images_dir}" | wc -l) -eq 0 ] && [ "$skip_images" = false ]; then
     echo "Images directory '${images_dir}' needs to contain at least one image. Aborting." >&2
     show_help_and_exit_error
-else
+elif [ "$skip_images" = false ]; then
     cp -r "$images_dir" "${temp_dir}/images"
 fi
 
 cp -r "$manifests_dir" "${temp_dir}/manifests"
 
 tar -C "${temp_dir}" -cf "${temp_dir}/manifests.tar" manifests
-tar -C "${temp_dir}" -czf "${temp_dir}/images.tar.gz" images
+artifact_files+=(-f "${temp_dir}/manifests.tar")
+if [ "$skip_images" = false ]; then
+    tar -C "${temp_dir}" -czf "${temp_dir}/images.tar.gz" images
+    artifact_files+=(-f "${temp_dir}/images.tar.gz")
+fi
 cat << EOF > "${temp_dir}/meta.json"
 {"version": "1", "project_name": "$project_name"}
 EOF
@@ -256,7 +267,7 @@ mender-artifact write module-image \
     --compression none \
     --artifact-name "${artifact_name}" \
     "${device_types[@]}" \
-    -f "${temp_dir}/images.tar.gz" -f "${temp_dir}/manifests.tar" \
+    "${artifact_files[@]}" \
     --meta-data "${temp_dir}/meta.json" \
     --output-path "${output_path}" \
     --software-name "${software_name}" \

--- a/tests/test_docker-compose.sh
+++ b/tests/test_docker-compose.sh
@@ -200,6 +200,47 @@ EOF
 }
 tests+=(test_artifact_install)
 
+test_artifact_install_pull_images() {
+    local rc=0
+
+    prepare_config
+    prepare_expected_file_tree
+    prepare_docker_mock
+
+    rm -f "${WORKDIR}/artifact-file-tree/files/images.tar.gz"
+
+    "${SRCDIR}/docker-compose" ArtifactInstall "${WORKDIR}/artifact-file-tree" > "${WORKDIR}/docker-compose.log" 2>&1 || rc=$?
+    if [ $rc -ne 0 ]; then
+        echo "ArtifactInstall failed (exit code $rc), logs follow:"
+        cat "${WORKDIR}/docker-compose.log"
+        return $rc
+    fi
+
+    cat << EOF | diff -u - "$CMDLINE_LOGGER_LOG_FILE" || rc=$?
+docker-compose --project-name test-comp pull
+docker images --format {{json .ID}} some/lighttpd:latest
+docker images --format {{json .ID}} bad/php:oldest
+docker-compose --project-name test-comp up --detach
+EOF
+    if [ $rc -ne 0 ]; then
+        echo "Unexpected commands executed (see the above diff), logs follow:"
+        cat "${WORKDIR}/docker-compose.log"
+        return $rc
+    fi
+
+    if ! [ -f "${PERSISTENT_DIR}/new/manifests/docker-compose.yml" ]; then
+        echo "New composition doesn't exist at the expected location"
+        return 1
+    fi
+    if ! [ -f "${PERSISTENT_DIR}/new/image_ids" ]; then
+        echo "Image IDs file doesn't exist at the expected location"
+        return 1
+    fi
+
+    return $rc
+}
+tests+=(test_artifact_install_pull_images)
+
 test_artifact_install_commit() {
     local rc=0
 


### PR DESCRIPTION
I’m sharing this PR to propose support for generating docker-compose artifacts without embedding container images.

The motivation is to reduce artifact size and bandwidth usage by avoiding shipping full image tarballs on every update, allowing devices to reuse cached layers where possible.

A similar approach has been discussed in the past for the _app-update-module_, and this PR explores whether the same functionality would be more feasible here.

I was wondering whether there would be interest in incorporating this here.