### PR TITLE
chore: Update mender-artifact arguments to match latest version

### DIFF
--- a/src/gen_docker-compose
+++ b/src/gen_docker-compose
@@ -110,7 +110,7 @@ while test $# -gt 0; do
             if [ -z "$2" ]; then
                 show_help_and_exit_error
             fi
-            device_types+=("-t" "$2")
+            device_types+=("--compatible-types" "$2")
             shift 2
             ;;
         --artifact-name | -n)


### PR DESCRIPTION
In the latest version of mender-artifact parameter `--device-type` has been replaced with `--compatible-types`. This requires update all mender-artifact calls which still use old version of argument name.

Ticket: MEN-9344