### PR TITLE
fix: cd into manifest dir beforing listing running containers

### DIFF
--- a/src/docker-compose
+++ b/src/docker-compose
@@ -152,11 +152,15 @@ comp_stop() {
 # logic to check if the containers started by a composition are healthy
 wait_healthy() {
     local project_name="$1"
+    local manifests_dir="$2"
     local timeout="$WAIT_TIMEOUT"
     local states
 
     while [ "$timeout" -gt 0 ]; do
-        local container_ids=$($DOCKER_COMPOSE_CMD --project-name "$project_name" ps --quiet)
+        local container_ids=$(
+            cd "$manifests_dir" \
+                                && $DOCKER_COMPOSE_CMD --project-name "$project_name" ps --quiet
+        )
         if [ -n "$container_ids" ]; then
             states=$($DOCKER_CMD inspect --format '{{.State.Status}}:{{if .State.Health}}{{.State.Health.Status}}{{else}}no_check{{end}}' $container_ids 2> /dev/null)
             local not_ready_count=$(echo "$states" | grep -v -E "^running:(healthy|no_check)$" | wc -l)
@@ -188,7 +192,7 @@ comp_start() {
     ) || rc=$?
 
     if test "$rc" -eq 0; then
-        wait_healthy "$project_name" || rc=$?
+        wait_healthy "$project_name" "$manifests_dir" || rc=$?
     fi
 
     if test "$rc" -ne 0; then


### PR DESCRIPTION
Fix an issue where docker-compose v1 can't find manifest files for a composition because we don't cd into the manifest directory.

Ticket: MEN-9641