### PR TITLE
refactor: Make most parts of the docker-compose UM reusable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+src/docker-compose

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,9 @@
 stages:
   - test
 
+variables:
+  LICENSE_HEADERS_IGNORE_FILES_REGEXP: '.*src/docker-compose_base\.sh'
+
 include:
   - component: gitlab.com/Northern.tech/Mender/mendertesting/commit-lint@master
   - project: 'Northern.tech/Mender/mendertesting'
@@ -13,6 +16,8 @@ include:
 
 test:check-shell-formatting:
   before_script:
+    - apk add --no-cache m4 make
+    - make build
     - SHELL_SCRIPTS="src/docker-compose src/gen_docker-compose tests/test_docker-compose.sh"
 
 test:unit-tests:
@@ -21,6 +26,7 @@ test:unit-tests:
     - oslo-xps
   before_script:
     - apt-get update
-    - apt-get -yyq install bash jq tar gzip
+    - apt-get -yyq install bash jq tar gzip m4 make
   script:
+    - make build
     - tests/test_docker-compose.sh

--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,16 @@ DESTDIR ?= /
 prefix ?= $(DESTDIR)
 moduledir ?= /usr/share/mender/modules/v3
 
-# No-op for this project
-build:
+build: src/docker-compose
+
+src/docker-compose: src/docker-compose.in src/docker-compose_base.sh
+	m4 --prefix-builtins --include=src src/docker-compose.in > $@
+	chmod a+x $@
 
 # "check" is common in many projects so let's have it as an alias
 check: test
 
-test:
+test: build
 	@tests/test_docker-compose.sh
 
 coverage:
@@ -17,7 +20,7 @@ coverage:
 clean:
 	rm -rf coverage
 
-install: install-docker-compose
+install: build install-docker-compose
 
 install-docker-compose:
 	install -d -m 755 $(prefix)$(moduledir)
@@ -28,6 +31,9 @@ uninstall: uninstall-docker-compose
 uninstall-docker-compose:
 	rm -f src/docker-compose $(prefix)$(moduledir)/docker-compose
 	-rmdir $(prefix)$(moduledir)
+
+# Tell Make to automatically delete corrupted output files on failure
+.DELETE_ON_ERROR:
 
 .PHONY: build
 .PHONY: check

--- a/src/docker-compose.in
+++ b/src/docker-compose.in
@@ -1,0 +1,109 @@
+#!/bin/sh
+# -*- mode: sh; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
+# Copyright 2026 Northern.tech AS
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+m4_dnl This is shell code with m4 commands/macros which requires preprocessing with
+m4_dnl m4 to produce a working script.
+m4_dnl
+m4_dnl Use --prefix-builtins when running m4 (include() becomes m4_include(),...) to
+m4_dnl avoid unintentional interpretation of builtin m4 macros in the code and
+m4_dnl comments.
+m4_dnl
+m4_dnl Make sure m4 does not interpret single quotes and back-ticks
+m4_changequote()
+m4_dnl
+# Uncomment the line below to get a very verbose output from this Update Module.
+# set -x
+
+set -e
+
+STATE="$1"
+FILES="$2"
+TEMP_DIR="$FILES"/tmp
+
+# Can be overriden by mender-docker-compose.conf
+WAIT_TIMEOUT=120
+
+m4_include(docker-compose_base.sh)
+
+# Allow overriding the config file path, primarily for tests.
+if [ -n "$MENDER_DOCKER_COMPOSE_CONFIG_FILE" ]; then
+    CONFIG_FILE="$MENDER_DOCKER_COMPOSE_CONFIG_FILE"
+else
+    CONFIG_FILE="/etc/mender/mender-docker-compose.conf"
+fi
+PERSISTENT_STORE="/data/mender-docker-compose"
+
+if test -f "$CONFIG_FILE"; then
+    . "$CONFIG_FILE"
+fi
+
+discover_requirements() {
+    discover_base_requirements
+}
+
+extract_images_from_artifact() {
+    local artifact_files="$1"
+
+    echo "extracting images"
+    $TAR_CMD -xzf "${artifact_files}/images.tar.gz" -C "$TEMP_DIR"
+}
+
+install_artifact() {
+    local artifact_files="$1"
+    local rc=0
+
+    echo "Installing docker-compose artifact ${ARTIFACT_NAME}"
+    install_composition_from_artifact "$artifact_files"
+}
+
+rollback_artifact() {
+    echo "Rolling back docker-compose artifact ${ARTIFACT_NAME}"
+    rollback_composition_from_artifact
+}
+
+case "$STATE" in
+    NeedsArtifactReboot)
+        echo "No"
+        ;;
+
+    SupportsRollback)
+        echo "Yes"
+        ;;
+
+    ArtifactInstall)
+        discover_requirements
+        parse_metadata "$FILES"/header/meta-data "$FILES"/header/header-info
+        install_artifact "$FILES"/files
+        ;;
+
+    ArtifactCommit)
+        discover_requirements
+        parse_metadata "$FILES"/header/meta-data "$FILES"/header/header-info
+        commit_artifact
+        ;;
+
+    ArtifactRollback)
+        discover_requirements
+        parse_metadata "$FILES"/header/meta-data "$FILES"/header/header-info
+        rollback_artifact
+        ;;
+
+    Cleanup)
+        discover_requirements
+        parse_metadata "$FILES"/header/meta-data "$FILES"/header/header-info
+        cleanup
+        ;;
+esac

--- a/src/docker-compose_base.sh
+++ b/src/docker-compose_base.sh
@@ -1,46 +1,22 @@
-#!/bin/sh
-# Copyright 2025 Northern.tech AS
-#
-#    Licensed under the Apache License, Version 2.0 (the "License");
-#    you may not use this file except in compliance with the License.
-#    You may obtain a copy of the License at
-#
-#        http://www.apache.org/licenses/LICENSE-2.0
-#
-#    Unless required by applicable law or agreed to in writing, software
-#    distributed under the License is distributed on an "AS IS" BASIS,
-#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#    See the License for the specific language governing permissions and
-#    limitations under the License.
-
-# Uncomment the line below to get a very verbose output from this Update Module.
-# set -x
-
-set -e
-
-STATE="$1"
-FILES="$2"
-TEMP_DIR="$FILES"/tmp
+m4_dnl -*- mode: sh; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
+m4_dnl # Copyright 2026 Northern.tech AS
+m4_dnl #
+m4_dnl #    Licensed under the Apache License, Version 2.0 (the "License");
+m4_dnl #    you may not use this file except in compliance with the License.
+m4_dnl #    You may obtain a copy of the License at
+m4_dnl #
+m4_dnl #        http://www.apache.org/licenses/LICENSE-2.0
+m4_dnl #
+m4_dnl #    Unless required by applicable law or agreed to in writing, software
+m4_dnl #    distributed under the License is distributed on an "AS IS" BASIS,
+m4_dnl #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+m4_dnl #    See the License for the specific language governing permissions and
+m4_dnl #    limitations under the License.
 
 JQ_CMD="jq"
 TAR_CMD="tar"
 DOCKER_CMD="docker"
 DOCKER_COMPOSE_CMD=""
-
-# Can be overriden by mender-docker-compose.conf
-WAIT_TIMEOUT=120
-
-# Allow overriding the config file path, primarily for tests.
-if [ -n "$MENDER_DOCKER_COMPOSE_CONFIG_FILE" ]; then
-    CONFIG_FILE="$MENDER_DOCKER_COMPOSE_CONFIG_FILE"
-else
-    CONFIG_FILE="/etc/mender/mender-docker-compose.conf"
-fi
-PERSISTENT_STORE="/data/mender-docker-compose"
-
-if test -f "$CONFIG_FILE"; then
-    . "$CONFIG_FILE"
-fi
 
 discover_docker_compose() {
     local rc=0
@@ -61,7 +37,7 @@ discover_docker_compose() {
     return $rc
 }
 
-discover_requirements() {
+discover_base_requirements() {
     local rc=0
 
     if ! $JQ_CMD --version > /dev/null 2>&1; then
@@ -221,11 +197,9 @@ get_manifest_image_ids() {
     done
 }
 
-install_artifact() {
+install_composition_from_artifact() {
     local artifact_files="$1"
     local rc=0
-
-    echo "Installing docker-compose artifact ${ARTIFACT_NAME}"
 
     if test -d "${PERSISTENT_STORE}/current"; then
         echo "saving existing composition as -previous"
@@ -248,8 +222,8 @@ install_artifact() {
         return 1
     fi
 
-    echo "extracting images"
-    $TAR_CMD -xzf "${artifact_files}/images.tar.gz" -C "$TEMP_DIR"
+    extract_images_from_artifact "$artifact_files"
+
     echo "extracting manifests"
     $TAR_CMD -xf "${artifact_files}/manifests.tar" -C "$TEMP_DIR"
 
@@ -284,8 +258,7 @@ commit_artifact() {
     fi
 }
 
-rollback_artifact() {
-    echo "Rolling back docker-compose artifact ${ARTIFACT_NAME}"
+rollback_composition_from_artifact() {
     if [ ! -d "${PERSISTENT_STORE}/new" ] && [ ! -d "${PERSISTENT_STORE}/previous" ]; then
         if test -d "${PERSISTENT_STORE}/current"; then
             # This may seem weird (and it is!), but rollback can be requested even
@@ -337,37 +310,3 @@ cleanup() {
 
     return $rc
 }
-
-case "$STATE" in
-    NeedsArtifactReboot)
-        echo "No"
-        ;;
-
-    SupportsRollback)
-        echo "Yes"
-        ;;
-
-    ArtifactInstall)
-        discover_requirements
-        parse_metadata "$FILES"/header/meta-data "$FILES"/header/header-info
-        install_artifact "$FILES"/files
-        ;;
-
-    ArtifactCommit)
-        discover_requirements
-        parse_metadata "$FILES"/header/meta-data "$FILES"/header/header-info
-        commit_artifact
-        ;;
-
-    ArtifactRollback)
-        discover_requirements
-        parse_metadata "$FILES"/header/meta-data "$FILES"/header/header-info
-        rollback_artifact
-        ;;
-
-    Cleanup)
-        discover_requirements
-        parse_metadata "$FILES"/header/meta-data "$FILES"/header/header-info
-        cleanup
-        ;;
-esac


### PR DESCRIPTION
So that other Update Modules utilizing docker-compose don't have to duplicate the code.

`m4` is used to handle merging of shell code into a standalone script at build time instead of using `source` and a more complicated setup with multiple files (and having to figure out where to put the extra ones).

Ticket: MEN-9442
Changelog: none