### PR TITLE
fix(docker-compose): Fail if extracting images from artifact fails

### DIFF
--- a/src/docker-compose_base.sh
+++ b/src/docker-compose_base.sh
@@ -222,7 +222,10 @@ install_composition_from_artifact() {
         return 1
     fi
 
-    extract_images_from_artifact "$artifact_files"
+    if ! extract_images_from_artifact "$artifact_files"; then
+        echo "ERROR: failed to extra images from artifact"
+        return 1
+    fi
 
     echo "extracting manifests"
     $TAR_CMD -xf "${artifact_files}/manifests.tar" -C "$TEMP_DIR"


### PR DESCRIPTION
Instead of inevitably failing at a later stage of artifact installation without a clear root cause.

Ticket: MEN-9442
Changelog: none